### PR TITLE
Compressing storage and fixing fuzzer underflow

### DIFF
--- a/medusa.json
+++ b/medusa.json
@@ -37,10 +37,10 @@
         "enabled": true,
         "testViewMethods": true,
         "panicCodeConfig": {
-          "failOnCompilerInsertedPanic": false,
+          "failOnCompilerInsertedPanic": true,
           "failOnAssertion": true,
-          "failOnArithmeticUnderflow": false,
-          "failOnDivideByZero": false,
+          "failOnArithmeticUnderflow": true,
+          "failOnDivideByZero": true,
           "failOnEnumTypeConversionOutOfBounds": false,
           "failOnIncorrectStorageAccess": false,
           "failOnPopEmptyArray": false,

--- a/src/LinearRewardsErc4626.sol
+++ b/src/LinearRewardsErc4626.sol
@@ -46,7 +46,7 @@ abstract contract LinearRewardsErc4626 is ERC4626 {
     struct RewardsCycleData {
         uint40 cycleEnd; // Timestamp of the end of the current rewards cycle
         uint40 lastSync; // Timestamp of the last time the rewards cycle was synced
-        uint216 rewardCycleAmount; // Amount of rewards to be distributed in the current cycle
+        uint192 rewardCycleAmount; // Amount of rewards to be distributed in the current cycle
     }
 
     /// @notice The rewards cycle data, stored in a single word to save gas
@@ -174,7 +174,7 @@ abstract contract LinearRewardsErc4626 is ERC4626 {
         }
 
         // Write return values
-        _rewardsCycleData.rewardCycleAmount = _newRewards.safeCastTo216();
+        _rewardsCycleData.rewardCycleAmount = _newRewards.safeCastTo192();
         _rewardsCycleData.lastSync = _timestamp.safeCastTo40();
         _rewardsCycleData.cycleEnd = _cycleEnd;
 
@@ -374,7 +374,7 @@ abstract contract LinearRewardsErc4626 is ERC4626 {
     /// @param cycleEnd The timestamp of the end of the current rewards cycle
     /// @param lastSync The timestamp of the last time the rewards cycle was synced
     /// @param rewardCycleAmount The amount of rewards to be distributed in the current cycle
-    event SyncRewards(uint40 cycleEnd, uint40 lastSync, uint216 rewardCycleAmount);
+    event SyncRewards(uint40 cycleEnd, uint40 lastSync, uint192 rewardCycleAmount);
 
     /// @notice The ```DistributeRewards``` event is emitted when rewards are distributed to storedTotalAssets
     /// @param rewardsToDistribute The amount of rewards that were distributed

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -197,4 +197,16 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
         senderAddr = 0x0000000000000000000000000000000000030000;
         erc4626_roundtrip_invariant_f(24);
     }
+
+    function testTotalAssetsUnderflow() public {
+        vm.roll(24624);
+        vm.warp(42699);
+        senderAddr = 0x0000000000000000000000000000000000020000;
+        rewardAccrual(24362008734939755575899403689284927106098404518490315928280918353459746106966);
+
+        vm.roll(24624);
+        vm.warp(42699);
+        senderAddr = 0x0000000000000000000000000000000000010000;
+        total_assets_below_total_balance();
+    }
 }

--- a/test/recon/Properties.sol
+++ b/test/recon/Properties.sol
@@ -3,18 +3,48 @@
 pragma solidity ^0.8.25;
 
 import {Asserts} from "@chimera/Asserts.sol";
+import {vm} from "@chimera/Hevm.sol";
 import {Setup} from "./Setup.sol";
 
 abstract contract Properties is Setup, Asserts {
-    function total_balance_below_actual_balance() public {
+    address internal senderAddr;
+    
+    modifier prepare() {
+        if (senderAddr == address(0)) {
+            senderAddr = msg.sender;
+        }
+
+        bool found;
+        for (uint256 i; i < senders.length; i++) {
+            if (senderAddr == senders[i]) {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            senders.push(senderAddr);
+        }
+
+        // block.timestamp can somtimes fall behind lastRewardsDistribution
+        // because we use warp in rewardAccrual. We need to make sure
+        // block.timestamp never falls behind lastRewardsDistribution the avoid
+        // underflow issues
+        if (block.timestamp < stakedEbtc.lastRewardsDistribution()) {
+            vm.warp(stakedEbtc.lastRewardsDistribution());
+        }
+        _;
+    }
+
+    function total_balance_below_actual_balance() public prepare {
         t(mockEbtc.balanceOf(address(stakedEbtc)) >= stakedEbtc.totalBalance(), "actualBalance >= totalBalance");
     }
 
-    function total_assets_below_total_balance() public {
+    function total_assets_below_total_balance() public prepare {
         t(stakedEbtc.totalBalance() >= stakedEbtc.totalAssets(), "totalBalance >= totalAssets");
     }
 
-    function sum_of_user_balances_equals_total_supply() public {
+    function sum_of_user_balances_equals_total_supply() public prepare {
         uint256 sumOfUserBalances;
         for (uint256 i; i < senders.length; i++) {
             sumOfUserBalances += stakedEbtc.balanceOf(senders[i]);
@@ -22,7 +52,7 @@ abstract contract Properties is Setup, Asserts {
         t(sumOfUserBalances == stakedEbtc.totalSupply(), "sumOfUserBalances == totalSupply");
     }
 
-    function sum_of_user_assets_equals_total_assets() public {
+    function sum_of_user_assets_equals_total_assets() public prepare {
         uint256 sumOfUserAssets;
         for (uint256 i; i < senders.length; i++) {
             sumOfUserAssets += stakedEbtc.convertToAssets(stakedEbtc.balanceOf(senders[i]));

--- a/test/recon/TargetFunctions.sol
+++ b/test/recon/TargetFunctions.sol
@@ -7,35 +7,10 @@ import {BeforeAfter} from "./BeforeAfter.sol";
 import {Properties} from "./Properties.sol";
 import {vm} from "@chimera/Hevm.sol";
 import "forge-std/console2.sol";
+import {LinearRewardsErc4626} from "src/LinearRewardsErc4626.sol";
 
 abstract contract TargetFunctions is BaseTargetFunctions, Properties, BeforeAfter {
     uint256 public constant MAX_EBTC = 1e27;
-    address internal senderAddr;
-
-    modifier prepare() {
-        if (senderAddr == address(0)) {
-            senderAddr = msg.sender;
-        }
-
-        bool found;
-        for (uint256 i; i < senders.length; i++) {
-            if (senderAddr == senders[i]) {
-                found = true;
-                break;
-            }
-        }
-
-        if (!found) {
-            senders.push(senderAddr);
-        }
-
-        // block.timestamp can somtimes fall behind lastRewardsDistribution
-        // Is this a medusa issue?
-        if (block.timestamp < stakedEbtc.lastRewardsDistribution()) {
-            vm.warp(stakedEbtc.lastRewardsDistribution());
-        }
-        _;
-    }
 
     function _checkPpfs() private {
         if (stakedEbtc.totalSupply() > 0) {
@@ -45,6 +20,14 @@ abstract contract TargetFunctions is BaseTargetFunctions, Properties, BeforeAfte
 
     function setSenderAddr(address newAddr) internal {
         senderAddr = newAddr;
+    }
+
+    function setMaxDistributionPerSecondPerAsset(uint256 amt) public prepare {
+        vm.prank(defaultGovernance);
+        try stakedEbtc.setMaxDistributionPerSecondPerAsset(amt) {
+        } catch {
+            t(false, "call shouldn't fail");
+        }
     }
 
     function setMintingFee(uint256 mintingFee) public prepare {
@@ -57,6 +40,21 @@ abstract contract TargetFunctions is BaseTargetFunctions, Properties, BeforeAfte
         }
     }
 
+
+    function calculateRewardsToDistribute(uint64 deltaTime) public prepare {
+        (uint40 cycleEnd, uint40 lastSync, uint192 rewardCycleAmount) = stakedEbtc.rewardsCycleData();
+        LinearRewardsErc4626.RewardsCycleData memory data = LinearRewardsErc4626.RewardsCycleData({
+            cycleEnd: cycleEnd,
+            lastSync: lastSync,
+            rewardCycleAmount: rewardCycleAmount
+        });
+
+        try stakedEbtc.calculateRewardsToDistribute(data, deltaTime) {
+        } catch {
+            t(false, "call shouldn't fail");
+        }
+    }
+    
     function sync_rewards_and_distribution_should_never_revert(uint256 ts) public prepare {
         ts = between(ts, 0, 500 * 52 weeks);
         vm.warp(block.timestamp + ts);


### PR DESCRIPTION
- Changing rewardCycleAmount from uint216 to uint192
- Fixing fuzzer underflow issue caused by warping in rewardAccrual