### PR TITLE
Feat simplify math and check griefs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ medusa/
 crytic-export/
 
 temp/
+
+# Python
+__pycache__

--- a/brute_force.py
+++ b/brute_force.py
@@ -1,0 +1,24 @@
+from math import exp
+
+UNIT = 1e18
+GOAL_PER_UNIT = 5e16
+
+SECONDS_PER_WEEK = 604800
+
+current_per_sec = 0
+increase_per_sec = 1e2
+result = 0
+while(result < GOAL_PER_UNIT):
+    current_per_sec += increase_per_sec
+    result = UNIT * current_per_sec * 52 * SECONDS_PER_WEEK / UNIT
+
+print("FOUND LINEAR", current_per_sec)
+print("RESULT FROM LINEAR", result)
+
+FROM_COMPOUND = ((1e18 * exp(0.05 * 1) - 1e18) / 365 / 24 / 60 / 60)
+RESULT_FROM_COMPOUND_CLAIMED_EACH_WEEK = UNIT * FROM_COMPOUND * 52 * SECONDS_PER_WEEK / UNIT
+
+print("FROM_COMPOUND", FROM_COMPOUND)
+print("RESULT_FROM_COMPOUND_CLAIMED_EACH_WEEK", RESULT_FROM_COMPOUND_CLAIMED_EACH_WEEK)
+
+print("ratio of compound / linear", FROM_COMPOUND / current_per_sec)

--- a/test/TestGrief.sol
+++ b/test/TestGrief.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.25;
+
+import "./BaseTest.sol";
+
+contract TestGrief is BaseTest {
+
+    address bob;
+    address alice;
+    address donald;
+
+    function setUp() public override {
+        /// BACKGROUND: deploy the StakedFrax contract
+        /// BACKGROUND: 10% APY cap
+        /// BACKGROUND: frax as the underlying asset
+        /// BACKGROUND: TIMELOCK_ADDRESS set as the timelock address
+        super.setUp();
+
+        bob = labelAndDeal(address(1234), "bob");
+        mintEbtcTo(bob, 1000 ether);
+        vm.prank(bob);
+        mockEbtc.approve(stakedFraxAddress, type(uint256).max);
+
+        alice = labelAndDeal(address(2345), "alice");
+        mintEbtcTo(alice, 1000 ether);
+        vm.prank(alice);
+        mockEbtc.approve(stakedFraxAddress, type(uint256).max);
+
+        donald = labelAndDeal(address(3456), "donald");
+        mintEbtcTo(donald, 1000 ether);
+        vm.prank(donald);
+        mockEbtc.approve(stakedFraxAddress, type(uint256).max);
+    }
+
+
+    function testGriefRewards() public {
+        vm.prank(bob);
+        stakedEbtc.deposit(10 ether, bob);
+
+        vm.prank(defaultGovernance);
+        governor.setUserRole(alice, 12, true);
+
+        vm.warp(block.timestamp + stakedEbtc.REWARDS_CYCLE_LENGTH() + 1);
+
+        // Sync and grief
+        stakedEbtc.syncRewardsAndDistribution();
+        (, , uint256 rewards) = stakedEbtc.rewardsCycleData();
+
+        assertEq(rewards, 0, "No rewards for a week");
+        vm.warp(block.timestamp + 1);
+
+        // Donate
+        vm.prank(defaultGovernance);
+        governor.setUserRole(alice, 12, true);
+
+        vm.prank(alice);
+        stakedEbtc.donate(1 ether);
+
+        // Will not revert
+        stakedEbtc.syncRewardsAndDistribution();
+
+        // But it's still at 0, rip
+        (, , uint256 rewardsAfter) = stakedEbtc.rewardsCycleData();
+        assertEq(rewards, rewardsAfter, "Griefed for an entire week");
+    }
+}


### PR DESCRIPTION
- [x] Ensure we can only perform upkeep after `executionDelay` has passed
- [x] Edge case in which the distribution was skipped, allows to claim at any time to catch up
- [ ] Testing, see comments
- [ ] Happy Tests
- [ ] Invariant on only being able to perform the operation if an epoch was skipped or if we are at the correct `executionDelay` in the current epoch
