### PR TITLE
Fix improve donation math

### DIFF
--- a/src/FeeRecipientDonationModule.sol
+++ b/src/FeeRecipientDonationModule.sol
@@ -304,7 +304,7 @@ contract FeeRecipientDonationModule is BaseModule, AutomationCompatible, Pausabl
 
     function isLateEnoughInTheCycle() public view returns (bool) {
         uint256 passedInCycle = getTimePassedInCycle();
-        return passedInCycle > executionDelay;  // enough time has passed
+        return passedInCycle > executionDelay;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/FeeRecipientDonationModule.sol
+++ b/src/FeeRecipientDonationModule.sol
@@ -287,8 +287,8 @@ contract FeeRecipientDonationModule is BaseModule, AutomationCompatible, Pausabl
     function getCurrentCycle() public view returns (uint256) {
         // Truncation of current time gives us current cycle
         // stBTC doesn't track cycle internally so we simply track it in this way
-        // We can get the start by multiplying * STAKED_EBTC.REWARDS_CYCLE_LENGTH()
-        // We can get the end by adding STAKED_EBTC.REWARDS_CYCLE_LENGTH() to the start
+        // We can get the `start` by multiplying * STAKED_EBTC.REWARDS_CYCLE_LENGTH()
+        // We can get the `end` by adding STAKED_EBTC.REWARDS_CYCLE_LENGTH() to the `start`
         uint256 currentCycle = block.timestamp / STAKED_EBTC.REWARDS_CYCLE_LENGTH();
 
         return currentCycle;

--- a/src/IStakedEbtc.sol
+++ b/src/IStakedEbtc.sol
@@ -12,4 +12,9 @@ interface IStakedEbtc {
     function storedTotalAssets() external view returns (uint256);
     function totalBalance() external view returns (uint256);
     function maxDistributionPerSecondPerAsset() external view returns (uint256);
+
+    function calculateRewardsToDistribute(
+        LinearRewardsErc4626.RewardsCycleData memory _rewardsCycleData,
+        uint256 _deltaTime
+    ) external view returns (uint256 _rewardToDistribute);
 }


### PR DESCRIPTION
- [x] Accrue `storedTotalAssets` to the end of the epoch
- [x] Refactor the code to no longer need `syncRewardsAndDistribution`

I would recommend writing the following tests:
- `checkUpkeep` should never revert with an overflow (try / catch, capture the error, assert it's not panic(17) nor panic(18)
- `checkUpkeep` should always calculate `totalAssetsToGiveYieldTo` correctly (This can be tested by computing the value and then forwarding to end of the cycle via warp)